### PR TITLE
error: pathspec '🐛' did not match any file(s) known to git.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icon-commit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "解决每次从 Typora 复制要使用的个性化 commit 语句，通过脚本输出语句可供选择，或者添加对应后缀来完成commit语句输出。🕹",
   "keywords": [
     "commit",

--- a/src/config/commitConfig.ts
+++ b/src/config/commitConfig.ts
@@ -81,5 +81,10 @@ export const COMMIT_CONFIG: CommitConfig[] = [
     commandName: CommitTypeEnum.version,
     description: '用于提交一个版本的更新标记',
     icon: Commit_Icons[CommitTypeEnum.version]
+  },
+  {
+    commandName: CommitTypeEnum.type,
+    description: '用于增删改查任何关于任何类型的提交',
+    icon: Commit_Icons[CommitTypeEnum.type]
   }
 ];

--- a/src/config/commitType.ts
+++ b/src/config/commitType.ts
@@ -14,6 +14,7 @@ export enum CommitTypeEnum {
   depend = 'depend',
   config = 'config',
   version = 'version',
+  type = "type"
 }
 
 export const Commit_Icons = {
@@ -32,6 +33,7 @@ export const Commit_Icons = {
   [CommitTypeEnum.depend]: '🧱',
   [CommitTypeEnum.config]: '🔧',
   [CommitTypeEnum.version]: '🎯',
+  [CommitTypeEnum.type]: '🌀',
 };
 
 export const Tag_Icon = '🔖';

--- a/src/execAll.ts
+++ b/src/execAll.ts
@@ -1,9 +1,9 @@
-import { exec } from 'shelljs';
-import { CommitTypeEnum, Commit_Icons, Tag_Icon } from './config/commitType';
+import { exec } from "shelljs";
+import { CommitTypeEnum, Commit_Icons, Tag_Icon } from "./config/commitType";
 interface BaseArg {
-  commitType?: CommitTypeEnum,
-  message: string
-  versionName?: string
+  commitType?: CommitTypeEnum;
+  message: string;
+  versionName?: string;
 }
 interface CommitAllProcessArg extends BaseArg {
   originName: string;
@@ -13,26 +13,26 @@ interface CommitAllProcessArg extends BaseArg {
 export const onGitCommit = (arg: BaseArg) => {
   const { commitType, message } = arg;
 
-  exec(`git commit -m '${commitType}: ${Commit_Icons[commitType]} ${message}'`);
+  exec(`git commit -m "${commitType}: ${Commit_Icons[commitType]} ${message}"`);
 };
 
 export const onGitCommitAllProcess = (arg: CommitAllProcessArg) => {
-  const { originName = 'origin', branch, commitType, message } = arg;
+  const { originName = "origin", branch, commitType, message } = arg;
 
   exec(`git add .`, { async: true });
-  onGitCommit({commitType, message});
+  onGitCommit({ commitType, message });
   exec(`git push ${originName} ${branch}`);
 };
 
 export const onGitCommitTag = (arg: BaseArg) => {
   const { versionName, message } = arg;
 
-  exec(`git tag -a ${versionName} -m '${Tag_Icon} ${message}'`);
+  exec(`git tag -a ${versionName} -m "${Tag_Icon} ${message}"`);
 };
 
 export const onGitCommitAllTag = (arg: BaseArg) => {
   const { versionName, message } = arg;
-  onGitCommitTag({versionName, message});
-  exec('git tag --list');
+  onGitCommitTag({ versionName, message });
+  exec("git tag --list");
   exec(`git push origin --tags`);
 };


### PR DESCRIPTION
在 Linux 系统中，commit 信息使用单引号 '，Windows 系统，commit 信息使用双引号 "。
所以在 git bash 中 git commit -m '提交说明' 这样是可以的，在 Windows 命令行中就要使用双引号 git commit -m "提交说明"。